### PR TITLE
fixed issue with search bar show all results button not working

### DIFF
--- a/src/components/navBar/searchBar/resultsBox.jsx/ResultsBox.scss
+++ b/src/components/navBar/searchBar/resultsBox.jsx/ResultsBox.scss
@@ -5,6 +5,7 @@
   margin-top: -3px;
   padding: 0px 16px;
   animation: stretch 1.5s;
+  position: relative;
   
   &-NoResults {
     @extend .ResultsBox;


### PR DESCRIPTION
Arreglo del boton de show all, por alguna razon os divs que vienen despues estan overlapeando la caja que se crea. He puesto position: relative. con eso se arregla.